### PR TITLE
Multi proofs backend

### DIFF
--- a/packages/db/prisma/migrations/20230927011433_add_merkleroot/migration.sql
+++ b/packages/db/prisma/migrations/20230927011433_add_merkleroot/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MembershipProof" ADD COLUMN     "merkleRoot" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -14,6 +14,7 @@ model MembershipProof {
   proofHash   String   @id
   proof       String
   publicInput String
+  merkleRoot  String?
   message     String
   craetedAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/packages/frontend/src/pages/api/proofs.ts
+++ b/packages/frontend/src/pages/api/proofs.ts
@@ -64,6 +64,10 @@ export default async function submitProof(req: NextApiRequest, res: NextApiRespo
     res.status(400).send({ error: 'Invalid merkle root' });
     return;
   }
+
+  // Convert merkle root to hex
+  const merkleRootHex = `0x${merkleRoot.toString(16)}`;
+
   const msgHash = publicInputDeserialized.msgHash;
   // Check that the message hashes to msgHash
   if (msgHash.toString() !== Buffer.from(hashMessage(message, 'bytes')).toString()) {
@@ -79,6 +83,7 @@ export default async function submitProof(req: NextApiRequest, res: NextApiRespo
     data: {
       message,
       proof,
+      merkleRoot: merkleRootHex,
       publicInput,
       proofHash,
     },

--- a/packages/frontend/src/pages/api/users/[handle]/proofs.ts
+++ b/packages/frontend/src/pages/api/users/[handle]/proofs.ts
@@ -1,0 +1,25 @@
+import prisma from '@/lib/prisma';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+// Get all proofs for a user
+export default async function getUserProofs(req: NextApiRequest, res: NextApiResponse) {
+  const handle = req.query.handle as string;
+
+  // Specify whether to include the raw proofs in the response.
+  // (Raw proofs are large so we make them optional)
+  const includeProofs = req.query.includeProofs === 'true';
+
+  const proofs = await prisma.membershipProof.findMany({
+    select: {
+      proof: includeProofs,
+      proofHash: true,
+      publicInput: true,
+      merkleRoot: true,
+    },
+    where: {
+      message: handle,
+    },
+  });
+
+  res.json(proofs);
+}


### PR DESCRIPTION
- Add a merkle root column so we can easily get the user -> set mapping
- I've set the column to be nullable so the db migration is non-destructive. If this backend looks good I can apply the migration to staging/prod.